### PR TITLE
Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ docs/build
 # ignore files with test tag.
 *_test*
 
-# the users pycharm workspace
+# the users workspace
 .idea/
-*.whl
+*install_pip.py
 dnppy_stat_report.txt
 

--- a/dnppy/__init__.py
+++ b/dnppy/__init__.py
@@ -7,9 +7,6 @@ participants and partners in earth science and remote sensing.
 Please consult the dnppy documentation pages for further information!
 """
 
-# dnppy version. follows [major revision].[year].[minor revision]
-__version__ = "1.15.3b0"
-
 # author list
 __author__ = ["Jwely",
               "djjensen",

--- a/dnppy/__init__.py
+++ b/dnppy/__init__.py
@@ -8,7 +8,7 @@ Please consult the dnppy documentation pages for further information!
 """
 
 # dnppy version. follows [major revision].[year].[minor revision]
-__version__ = "1.15.3"
+__version__ = "1.15.3b0"
 
 # author list
 __author__ = ["Jwely",

--- a/install_dependencies.py
+++ b/install_dependencies.py
@@ -23,7 +23,13 @@ def get_pip():
     try:
         import pip
 
+        if pip.__version__ < "7.1.1":
+            raise ImportError       # just raise an import error for outdated version
+
+
     except ImportError:
+
+        # download pip installation file
         with open("install_pip.py", 'wb+') as f:
             connection = urllib.urlopen("https://bootstrap.pypa.io/get-pip.py")
             page = connection.read()
@@ -34,8 +40,13 @@ def get_pip():
         # run pip and clean up.
         import install_pip
 
+        # run then remove install_pip
         os.system("install_pip.py")
         os.remove("install_pip.py")
+
+        # use pip to upgrade itself
+        import pip
+        pip.main(["install", "--upgrade", "pip"])
 
 
 def check_process_lock():
@@ -171,7 +182,8 @@ def main():
                          release_address + "Shapely-1.5.9-cp27-none-win32.whl"]
     }
 
-    pip_versions = {"matplotlib": None,  # for making plots! users with arcpy already have this!
+    pip_versions = {"setuptools": None,  # installs setuptools? maybe not needed?
+                    "matplotlib": None,  # for making plots! users with arcpy already have this!
                     "wheel": None,       # for installing other dependencies
                     "requests": None,    # for better web interfacing
                     "psutil": None,      # for killing processes which might lock files we want to modify

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@
 
 
 # sets up dependencies that pip alone seems to frequently fail at.
-import install_dependencies
-install_dependencies.main()
+#import install_dependencies
+#install_dependencies.main()
 
 # standard setup
 from distutils.core import setup
@@ -22,8 +22,14 @@ setup(name='dnppy',
               ],
       author_email='jeff.ely.08@gmail.com',
       url='https://github.com/NASA-DEVELOP/dnppy',
+      download_url = "https://github.com/NASA-DEVELOP/dnppy/archive/setup.zip",
       packages=find_packages(),
       include_package_data = True,
+      entry_points= {'console_scripts' : ['install_dependencies=install_dependencies:main']}
      )
 
-print("setup finished")
+
+# quick setup that will work locally by running this script
+if __name__ == "__main__":
+    import pip
+    pip.main(["install", "--upgrade", "https://github.com/NASA-DEVELOP/dnppy/archive/setup.zip"])

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='dnppy',
               ],
       author_email='jeff.ely.08@gmail.com',
       url='https://github.com/NASA-DEVELOP/dnppy',
-      download_url = "https://github.com/NASA-DEVELOP/dnppy/archive/setup.zip",
+      download_url = "https://github.com/NASA-DEVELOP/dnppy/archive/master.zip",
       packages=find_packages(),
       include_package_data = True,
      )

--- a/setup.py
+++ b/setup.py
@@ -1,116 +1,29 @@
-"""
-This is a barebones install script to install the dnppy module
- 
- It simply checks the version numbers indicated in __init__.py and
- copies the dnppy_install folder contents into a new folder named
- dnppy in the site-packages folder in the currently running python library.
+""" installs dnppy """
 
- It duplicates this action for a version specific named folder so users can
- switch back and forth between old and new versions by explicitly importing,
- for example:
 
-   from dnppy0.0.2     import core as old_core
-   from dnppy1.15.1    import core as new_core
-
- If you have knowledge of setuptools and time to make this setuptools compatible and
- can allow dnppy installation with pip directly, please do so.
-"""
-
-import os
-import shutil
-import time
+# sets up dependencies that pip alone seems to frequently fail at.
 import install_dependencies
+install_dependencies.main()
 
+# standard setup
+from distutils.core import setup
+from setuptools import find_packages
 
-def setup():
-    """ performs setup of dnppy by copying files to site-packages """
+setup(name='dnppy',
+      version='1.15.3b0',
+      description='DEVELOP National Program Python Package',
+      author=["Jwely",
+              "djjensen",
+              "Syntaf",
+              "lancewatkins",
+              "lmakely",
+              "qgeddes",
+              "Scott Baron",
+              ],
+      author_email='jeff.ely.08@gmail.com',
+      url='https://github.com/NASA-DEVELOP/dnppy',
+      packages=find_packages(),
+      include_package_data = True,
+     )
 
-    import dnppy
-
-    library_path, _ = os.path.split(os.__file__)
-    source_path, _  = os.path.split(dnppy.__file__)
-    dest_path       = os.path.join(library_path, 'site-packages', 'dnppy')
-    dest_path2      = dest_path + dnppy.__version__
-
-    if os.path.isdir(dest_path):
-        try:
-
-            print("\nUpdating to version [{0}]...".format(dnppy.__version__))
-
-            shutil.rmtree(dest_path)
-            shutil.copytree(source_path, dest_path)
-
-            try: shutil.rmtree(dest_path2)
-            except: pass
-
-            shutil.copytree(source_path, dest_path2)
-
-
-        # handles the case where dnppy is installed, but cannot import for some reason.
-        except:
-            print("installing dnppy version [{0}]".format(dnppy.__version__))
-            shutil.rmtree(dest_path)
-            shutil.rmtree(dest_path2)
-            shutil.copytree(source_path, dest_path)
-            shutil.copytree(source_path, dest_path2)
-    else:
-        print("installing dnppy version [{0}]".format(dnppy.__version__))
-        shutil.copytree(source_path, dest_path)
-        shutil.copytree(source_path, dest_path2)
-
-    print('\nSource path       : ' + source_path)
-    print('Destination path 1: '   + dest_path)
-    print('Destination path 2: '   + dest_path2)
-
-
-def test_setup():
-    """ returns True if all modules of dnppy import properly"""
-
-    # ensure every module imports OK
-    print("convert")
-    from dnppy import convert
-    print("core")
-    from dnppy import core
-    print("download")
-    from dnppy import download
-    print("landsat")
-    from dnppy import landsat
-    print("modis")
-    from dnppy import modis
-    print("radar")
-    from dnppy import radar
-    print("raster")
-    from dnppy import raster
-    print("solar")
-    from dnppy import solar
-    print("textio")
-    from dnppy import textio
-    print("time_series")
-    from dnppy import time_series
-    return True
-
-
-def main():
-    """ main function for installing dnppy """
-
-    print("====================================================================")
-    print("   Setting up dnppy! the DEVELOP National Program python package!")
-    print("====================================================================")
-
-    print("\nSetting up other libraries!")
-    install_dependencies.main()
-    setup()
-
-    print("\nValidating setup of each module...")
-    if test_setup() is True:
-        print("\nSetup was successful!")
-    else:
-        print("\nSetup has failed!")
-
-    print("You may close this window")
-    time.sleep(20)
-    # sys.exit()
-
-
-if __name__ == "__main__":
-    main()
+print("setup finished")

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@
 
 
 # sets up dependencies that pip alone seems to frequently fail at.
-#import install_dependencies
-#install_dependencies.main()
+import install_dependencies
+install_dependencies.main()
 
 # standard setup
 from distutils.core import setup
@@ -25,11 +25,11 @@ setup(name='dnppy',
       download_url = "https://github.com/NASA-DEVELOP/dnppy/archive/setup.zip",
       packages=find_packages(),
       include_package_data = True,
-      entry_points= {'console_scripts' : ['install_dependencies=install_dependencies:main']}
      )
 
 
 # quick setup that will work locally by running this script
 if __name__ == "__main__":
     import pip
-    pip.main(["install", "--upgrade", "https://github.com/NASA-DEVELOP/dnppy/archive/setup.zip"])
+    # pip.main(["install", "--upgrade", "https://github.com/NASA-DEVELOP/dnppy/archive/setup.zip"])
+    pip.main(["install", "--upgrade", "dnppy"])


### PR DESCRIPTION
setup now uses setuptools like it should. Allows dnppy to be installed with:

``` python
import pip
pip.main(["install","https://github.com/NASA-DEVELOP/dnppy/archive/master.zip"])
```
